### PR TITLE
add event.preventDefault() to smoothScroll

### DIFF
--- a/src/lib/smoothScroll.js
+++ b/src/lib/smoothScroll.js
@@ -9,7 +9,8 @@
 import $ from 'jquery';
 
 export function initSmoothScrollToAnchor(time = 500) {
-  $('a[href*="#"]:not([href="#"])').click(function smoothScrollToAnchor() {
+  $('a[href*="#"]:not([href="#"])').click(function smoothScrollToAnchor(event) {
+    event.preventDefault();
     if (window.location.pathname.replace(/^\//, '') === this.pathname.replace(/^\//, '')
       && window.location.hostname === this.hostname) {
       let target = $(this.hash);


### PR DESCRIPTION
This fixes a bug where on first click after page load, the window will jump to the anchor immediately